### PR TITLE
Add callback to dataLoadComplete

### DIFF
--- a/src/GeoJSON.js
+++ b/src/GeoJSON.js
@@ -35,6 +35,7 @@ L.GeoJSON.AJAX = L.GeoJSON.extend({
 			if (this.filter) {
 				this.refilter(this.filter);
 			}
+			if (typeof options.onComplete === 'function') options.onComplete(this._layers);
 		}, this);
 		if (this.urls.length > 0) {
 			this.addUrl();


### PR DESCRIPTION
Use case:

new L.GeoJSON.AJAX(url, {
    onComplete: function(layers){
         //fade in
    }
}).addTo(map);

What do you think? Is there a way to attach a listener using .on()?
